### PR TITLE
Added Unique Index on plate column and added Foreign Key Relationship

### DIFF
--- a/vehshop.sql
+++ b/vehshop.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS `player_vehicles` (
   `vehicle` varchar(50) DEFAULT NULL,
   `hash` varchar(50) DEFAULT NULL,
   `mods` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
-  `plate` varchar(50) NOT NULL,
+  `plate` varchar(15) NOT NULL,
   `fakeplate` varchar(50) DEFAULT NULL,
   `garage` varchar(50) DEFAULT NULL,
   `fuel` int(11) DEFAULT 100,
@@ -24,3 +24,10 @@ CREATE TABLE IF NOT EXISTS `player_vehicles` (
   KEY `citizenid` (`citizenid`),
   KEY `license` (`license`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1;
+
+ALTER TABLE `player_vehicles`
+ADD UNIQUE INDEX UK_playervehicles_plate (plate);
+
+ALTER TABLE `player_vehicles`
+ADD CONSTRAINT FK_playervehicles_players FOREIGN KEY (citizenid)
+REFERENCES `players` (citizenid) ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
1. Added Unique Index on plate column. It is possible to have multiple owners of a vehicle which doesn't seem correct. Makign this unique is also required for the next change
2.  Added Foreign Key Relationship to players table to create a 1..* constraint. Without constraints it's possible to create invalid orphaned data in child tables. Also added CASCADE on DELETE and UPDATE to avoid orphaned child table data as well as make it simpler to change the plate of a vehicle. Without CASCADE UPDATE you need to run two UPDATE statements which done from LUA initiates two handshakes to connect to the RDBMS. The ways around this are to create a stored procedure on the RDBS and change the execute statement in the LUA, or simply create this relationship with CASCADES and it happens trnasparently without LUA changes.

I plan to push through many other sql changes across the entire qbcore stack, but I will wait until I get feedback on this PR. I f you're not happy with the design the I won't proceeed any further and just keep the changes on our own server. I consider this to be an extremely important change to FiveM RP servers. We've had records on tables that never had a corresponding value in reference tables which is indicative that modders have been able to trigger events that stored data in attempts to gain advantages. By locking out these options with database level constraints you add protection to your data.
