### PR TITLE
Bicycles now in PDM as stated by shared/vehicles.lua

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -36,7 +36,8 @@ Config.Shops = {
             ['muscle'] = 'Muscle',
             ['compacts'] = 'Compacts',
             ['motorcycles'] = 'Motorcycles',
-            ['vans'] = 'Vans'
+            ['vans'] = 'Vans',
+            ['cycles'] = 'Bicycles'
         },
         ['TestDriveTimeLimit'] = 0.5, -- Time in minutes until the vehicle gets deleted
         ['Location'] = vector3(-45.67, -1098.34, 26.42), -- Blip Location


### PR DESCRIPTION
This is the fix to bug #415 in qb-core
Added cycles to PDM to allow them to be purchased. Since they are already in the shared\vehicles.lua