### PR TITLE
Update client.lua

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -139,6 +139,7 @@ local function createTestDriveReturn()
 
     testDriveZone:onPlayerInOut(function(isPointInside)
         if isPointInside and IsPedInAnyVehicle(PlayerPedId()) then
+			SetVehicleForwardSpeed(GetVehiclePedIsIn(PlayerPedId(), false), 0)
             exports['qb-menu']:openMenu(returnTestDrive)
         else
             exports['qb-menu']:closeMenu()


### PR DESCRIPTION
Sets the vehicle speed to 0 when the vehicle enters the return zone for test drive. Player loses all keyboard/mouse functionality when they enter so this helps stop the vehicle upon entering the zone.