### PR TITLE
fix(playerDropped): Multiple Financed Cars Error

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -23,7 +23,7 @@ RegisterNetEvent('qb-vehicleshop:server:removePlayer', function(citizenid)
             end
         end
     end
-    financetimer[citizenid] = {}
+    financetimer[citizenid] = nil
 end)
 
 -- Deduct stored game time from player on quit because we can't get citizenid
@@ -36,19 +36,17 @@ AddEventHandler('playerDropped', function()
     end
     if license then
         local vehicles = exports.oxmysql:executeSync('SELECT * FROM player_vehicles WHERE license = ?', {license})
-        if vehicles then
+        if vehicles and financetimer[v.citizenid] then
             for k,v in pairs(vehicles) do
-                if financetimer[v.citizenid] then
-                    local playTime = financetimer[v.citizenid]
-                    if v.balance >= 1 then
-                        local newTime = math.floor(v.financetime - (((GetGameTimer() - playTime) / 1000) / 60))
-                        if newTime < 0 then newTime = 0 end
-                        exports.oxmysql:update('UPDATE player_vehicles SET financetime = ? WHERE plate = ?', {newTime, v.plate})
-                        financetimer[v.citizenid] = {}
-                    end
+                local playTime = financetimer[v.citizenid]
+                if v.balance >= 1 then
+                    local newTime = math.floor(v.financetime - (((GetGameTimer() - playTime) / 1000) / 60))
+                    if newTime < 0 then newTime = 0 end
+                    exports.oxmysql:update('UPDATE player_vehicles SET financetime = ? WHERE plate = ?', {newTime, v.plate})
                 end
             end
         end
+        financetimer[v.citizenid] = nil
     end
 end)
 


### PR DESCRIPTION
This should resolve the error for playTIme being nil when a player leave the server. The error only happens if they have more than one financed vehicles and it is because after the first vehicle gets updated it sets the table entry to an empty table and no longer the join server time.

Also I changed it from setting as an empty table to nil to remove the entry from the table entirely.