### PR TITLE
Fix duplicated vehicle zones

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -766,7 +766,8 @@ CreateThread(function()
             SetEntityHeading(veh, Config.Shops[k]["ShowroomVehicles"][i].coords.w)
             FreezeEntityPosition(veh,true)
             SetVehicleNumberPlateText(veh, 'BUY ME')
-            createVehZones(k)
         end
+			
+        createVehZones(k)
     end
 end)


### PR DESCRIPTION
The `createVehZones` function is being called every time a showroom vehicle is created. If you have 7 showroom vehicles for example, you'll end up with 49 zones!