### PR TITLE
Correct minDown payment $ to allow proper % calc

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -235,7 +235,7 @@ RegisterNetEvent('qb-vehicleshop:server:financeVehicle', function(downPayment, p
     local bank = pData.PlayerData.money['bank']
     local vehiclePrice = QBCore.Shared.Vehicles[vehicle]['price']
     local timer = (Config.PaymentInterval * 60)
-    local minDown = tonumber(round(vehiclePrice / Config.MinimumDown))
+    local minDown = tonumber(round((Config.MinimumDown/100) * vehiclePrice))
     if downPayment > vehiclePrice then return TriggerClientEvent('QBCore:Notify', src, 'Vehicle is not worth that much', 'error') end
     if downPayment < minDown then return TriggerClientEvent('QBCore:Notify', src, 'Down payment too small', 'error') end
     if paymentAmount > Config.MaximumPayments then return TriggerClientEvent('QBCore:Notify', src, 'Exceeded maximum payment amount', 'error') end

--- a/server.lua
+++ b/server.lua
@@ -353,7 +353,7 @@ RegisterNetEvent('qb-vehicleshop:server:sellfinanceVehicle', function(downPaymen
         local bank = target.PlayerData.money['bank']
         local vehiclePrice = QBCore.Shared.Vehicles[vehicle]['price']
         local timer = (Config.PaymentInterval * 60)
-        local minDown = tonumber(round(vehiclePrice / Config.MinimumDown))
+        local minDown = tonumber(round((Config.MinimumDown/100) * vehiclePrice))
         if downPayment > vehiclePrice then return TriggerClientEvent('QBCore:Notify', src, 'Vehicle is not worth that much', 'error') end
         if downPayment < minDown then return TriggerClientEvent('QBCore:Notify', src, 'Down payment too small', 'error') end
         if paymentAmount > Config.MaximumPayments then return TriggerClientEvent('QBCore:Notify', src, 'Exceeded maximum payment amount', 'error') end


### PR DESCRIPTION
Fixes the down payment calculation. Previously it was just dividing by the # in Config.MinimumDown causing stupid low down payments

Config.MinimumDown = 80 
Before:
![Screenshot 2022-01-15 115944](https://user-images.githubusercontent.com/87187094/149630622-f54b3af3-42ff-4d87-a0e8-89ea2daf6b75.png)

After:
![Screenshot 2022-01-15 115929](https://user-images.githubusercontent.com/87187094/149630623-08547a87-e133-47e7-a904-69e31bb3319f.png)

