### PR TITLE
transfervehicle command fix

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -363,6 +363,18 @@ end
 
 -- Events
 
+RegisterNetEvent('qb-vehicleshop:client:transferVehicle', function(buyerId, amount)
+    local ped = PlayerPedId()
+    local vehicle = GetVehiclePedIsIn(ped, false)
+    local plate = QBCore.Functions.GetPlate(vehicle)
+    local tcoords = GetEntityCoords(GetPlayerPed(GetPlayerFromServerId(buyerId)))
+    if #(GetEntityCoords(ped)-tcoords) < 5.0 then
+        TriggerServerEvent('qb-vehicleshop:server:transferVehicle', plate, buyerId, amount)
+    else
+        QBCore.Functions.Notify('The person you are selling to is too far away.')
+    end
+end)
+
 RegisterNetEvent('qb-vehicleshop:client:homeMenu', function()
     exports['qb-menu']:openMenu(vehicleMenu)
 end)

--- a/server.lua
+++ b/server.lua
@@ -429,41 +429,53 @@ RegisterNetEvent('qb-vehicleshop:server:checkFinance', function()
 end)
 
 -- Transfer vehicle to player in passenger seat
-QBCore.Commands.Add('transferVehicle', 'Gift or sell your vehicle', {{ name = 'amount', help = 'Sell amount' }}, false, function(source, args)
+RegisterNetEvent('qb-vehicleshop:server:transferVehicle', function(plate, buyerId, amount)
     local src = source
+    local plate = plate
+    local buyerId = tonumber(buyerId)
+    local sellAmount = tonumber(amount)
     local ped = GetPlayerPed(src)
     local player = QBCore.Functions.GetPlayer(src)
+    local target = QBCore.Functions.GetPlayer(buyerId)
     local citizenid = player.PlayerData.citizenid
-    local sellAmount = tonumber(args[1])
-    local vehicle = GetVehiclePedIsIn(ped, false)
-    if vehicle == 0 then return TriggerClientEvent('QBCore:Notify', src, 'Must be in a vehicle', 'error') end
-    local driver = GetPedInVehicleSeat(vehicle, -1)
-    local passenger = GetPedInVehicleSeat(vehicle, 0)
-    local plate = QBCore.Functions.GetPlate(vehicle)
-    local isOwned = MySQL.Sync.fetchScalar('SELECT citizenid FROM player_vehicles WHERE plate = ?', {plate})
-    if isOwned ~= citizenid then return TriggerClientEvent('QBCore:Notify', src, 'You dont own this vehicle', 'error') end
-    if ped ~= driver then return TriggerClientEvent('QBCore:Notify', src, 'Must be driver', 'error') end
-    if passenger == 0 then return TriggerClientEvent('QBCore:Notify', src, 'No passenger', 'error') end
-    local targetid = NetworkGetEntityOwner(passenger)
-    local target = QBCore.Functions.GetPlayer(targetid)
-    if not target then return TriggerClientEvent('QBCore:Notify', src, 'Couldnt get passenger info', 'error') end
-    if sellAmount then
-        if target.Functions.GetMoney('cash') > sellAmount then
+    if target ~= nil then
+        if sellAmount then
+            if target.Functions.GetMoney('cash') > sellAmount then
+                local targetcid = target.PlayerData.citizenid
+                MySQL.Async.execute('UPDATE player_vehicles SET citizenid = ? WHERE plate = ?', {targetcid, plate})
+                player.Functions.AddMoney('cash', sellAmount)
+                TriggerClientEvent('QBCore:Notify', src, 'You sold your vehicle for $'..comma_value(sellAmount), 'success')
+                target.Functions.RemoveMoney('cash', sellAmount)
+                TriggerClientEvent('vehiclekeys:client:SetOwner', target.PlayerData.source, plate)
+                TriggerClientEvent('QBCore:Notify', target.PlayerData.source, 'You bought a vehicle for $'..comma_value(sellAmount), 'success')
+            elseif target.Functions.GetMoney('bank') > sellAmount then
+                local targetcid = target.PlayerData.citizenid
+                MySQL.Async.execute('UPDATE player_vehicles SET citizenid = ? WHERE plate = ?', {targetcid, plate})
+                player.Functions.AddMoney('bank', sellAmount)
+                TriggerClientEvent('QBCore:Notify', src, 'You sold your vehicle for $'..comma_value(sellAmount), 'success')
+                target.Functions.RemoveMoney('bank', sellAmount)
+                TriggerClientEvent('vehiclekeys:client:SetOwner', target.PlayerData.source, plate)
+                TriggerClientEvent('QBCore:Notify', target.PlayerData.source, 'You bought a vehicle for $'..comma_value(sellAmount), 'success')
+            else
+                TriggerClientEvent('QBCore:Notify', src, 'Not enough money', 'error')
+            end
+        else
             local targetcid = target.PlayerData.citizenid
             MySQL.Async.execute('UPDATE player_vehicles SET citizenid = ? WHERE plate = ?', {targetcid, plate})
-            player.Functions.AddMoney('cash', sellAmount)
-            TriggerClientEvent('QBCore:Notify', src, 'You sold your vehicle for $'..comma_value(sellAmount), 'success')
-            target.Functions.RemoveMoney('cash', sellAmount)
+            TriggerClientEvent('QBCore:Notify', src, 'You gifted your vehicle', 'success')
             TriggerClientEvent('vehiclekeys:client:SetOwner', target.PlayerData.source, plate)
-            TriggerClientEvent('QBCore:Notify', target.PlayerData.source, 'You bought a vehicle for $'..comma_value(sellAmount), 'success')
-        else
-            TriggerClientEvent('QBCore:Notify', src, 'Not enough money', 'error')
+            TriggerClientEvent('QBCore:Notify', target.PlayerData.source, 'You were gifted a vehicle', 'success')
         end
     else
-        local targetcid = target.PlayerData.citizenid
-        MySQL.Async.execute('UPDATE player_vehicles SET citizenid = ? WHERE plate = ?', {targetcid, plate})
-        TriggerClientEvent('QBCore:Notify', src, 'You gifted your vehicle', 'success')
-        TriggerClientEvent('vehiclekeys:client:SetOwner', target.PlayerData.source, plate)
-        TriggerClientEvent('QBCore:Notify', target.PlayerData.source, 'You were gifted a vehicle', 'success')
+        TriggerClientEvent('QBCore:Notify', src, 'Couldn\'t get purchaser info.', 'error')
     end
-end, 'user')
+end)
+
+-- Transfer vehicle to player in passenger seat
+QBCore.Commands.Add('transferVehicle', 'Gift or sell your vehicle', {{name = 'ID', help = 'ID of buyer'}, {name = 'amount', help = 'Sell amount'}}, false, function(source, args)
+    if args[1] ~= nil and args[2] ~= nil then
+        TriggerClientEvent('qb-vehicleshop:client:transferVehicle', source, args[1], args[2])
+    else
+        TriggerClientEvent('QBCore:Notify', source, 'Check who you\'re selling to or the amount to sell for.', 'error')
+    end
+end)


### PR DESCRIPTION
A fix to the transfervehicle command as the getplate command is only available client side, and was previously being used server side.

Takes the player id of the purchaser as argument 1 and the amount as argument 2.

Also allows purchasing from bank money if the cash is not on the person.