### PR TITLE
check insideShop for correct polyzone init

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -186,7 +186,7 @@ local function createVehZones(shopName) -- This will create an entity zone if co
         local combo = ComboZone:Create(zones, {name = "vehCombo", debugPoly = false})
         combo:onPlayerInOut(function(isPointInside)
             local insideShop = getShopInsideOf()
-            if isPointInside then
+            if isPointInside and insideShop ~= nil then
                 if PlayerData.job.name == Config.Shops[insideShop]['Job'] or Config.Shops[insideShop]['Job'] == 'none' then
                     exports['qb-menu']:showHeader(vehHeaderMenu)
                 end


### PR DESCRIPTION
Fix for users experiencing #133 

Variables not initialized when teleported back to polyzone. 

187:combo:onPlayerInOut runs continously when player is in polyzone and so allowing for nil values can be extended to the `insideShop` variable that looks for a nearby shop once the player has entered the polyZone, but the coordinates of the player is not close enough to the shop for the `getShopInsideOf()` function to run.