### PR TITLE
Attempt to index a nil value fix on swap vehicle

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -561,7 +561,7 @@ RegisterNetEvent('qb-vehicleshop:client:openCustomFinance', function(data)
 end)
 
 RegisterNetEvent('qb-vehicleshop:client:swapVehicle', function(data)
-    local shopName = getShopInsideOf()
+    local shopName = data.ClosestShop
     if Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].chosenVehicle ~= data.toVehicle then
         local closestVehicle, closestDistance = QBCore.Functions.GetClosestVehicle(vector3(Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.x, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.y, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.z))
         if closestVehicle == 0 then return end


### PR DESCRIPTION
This fixes a client error that happens to players outside of a shop when another player requests to swap the vehicle. The previous code would run the getShopInsideOf() method, but the other player would not be in a shop and get the error. The closestShop is already passed to the server event on a swap request, so we can just use that data here to know which shop to swap the vehicle in.