### PR TITLE
Fix Finance menu from showing all vehicles

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -612,7 +612,7 @@ RegisterNetEvent('qb-vehicleshop:client:getVehicles', function()
     QBCore.Functions.TriggerCallback('qb-vehicleshop:server:getVehicles', function(vehicles)
         local ownedVehicles = {}
         for k,v in pairs(vehicles) do
-            if v.balance then
+            if v.balance ~= 0 then
                 local name = QBCore.Shared.Vehicles[v.vehicle]["name"]
                 local plate = v.plate:upper()
                 ownedVehicles[#ownedVehicles + 1] = {


### PR DESCRIPTION
Finance menu was showing all owned vehicles since balance is 0 by default and not nil in the DB. To fix this I added a small check to the event 'qb-vehicleshop:client:getVehicles' to ensure it did not retrieve vehicles with a equal to zero. 

Now the menu only displays vehicles with a balance rather than every owned vehicle.

Tested and working on my latest qb-core server.