### PR TITLE
swapVehicle data delay fix

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -568,21 +568,26 @@ RegisterNetEvent('qb-vehicleshop:client:swapVehicle', function(data)
         local closestVehicle, closestDistance = QBCore.Functions.GetClosestVehicle(vector3(Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.x, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.y, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.z))
         if closestVehicle == 0 then return end
         if closestDistance < 5 then QBCore.Functions.DeleteVehicle(closestVehicle) end
-        Wait(250)
+        while DoesEntityExist(closestVehicle) do
+            Wait(250)
+        end
+        Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].chosenVehicle = data.toVehicle
         local model = GetHashKey(data.toVehicle)
         RequestModel(model)
         while not HasModelLoaded(model) do
             Citizen.Wait(250)
         end
         local veh = CreateVehicle(model, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.x, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.y, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.z, false, false)
-        SetModelAsNoLongerNeeded(model)
+        while not DoesEntityExist(veh) do
+            Citizen.Wait(250)
+        end
+        SetModelAsNoLongerNeeded(model)        
         SetVehicleOnGroundProperly(veh)
         SetEntityInvincible(veh,true)
         SetEntityHeading(veh, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.w)
         SetVehicleDoorsLocked(veh, 3)
         FreezeEntityPosition(veh, true)
-        SetVehicleNumberPlateText(veh, 'BUY ME')
-        Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].chosenVehicle = data.toVehicle
+        SetVehicleNumberPlateText(veh, 'BUY ME') 
         if Config.UsingTarget then createVehZones(shopName, veh) end
     end
 end)

--- a/client.lua
+++ b/client.lua
@@ -569,17 +569,17 @@ RegisterNetEvent('qb-vehicleshop:client:swapVehicle', function(data)
         if closestVehicle == 0 then return end
         if closestDistance < 5 then QBCore.Functions.DeleteVehicle(closestVehicle) end
         while DoesEntityExist(closestVehicle) do
-            Wait(250)
+            Wait(50)
         end
         Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].chosenVehicle = data.toVehicle
         local model = GetHashKey(data.toVehicle)
         RequestModel(model)
         while not HasModelLoaded(model) do
-            Citizen.Wait(250)
+            Wait(50)
         end
         local veh = CreateVehicle(model, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.x, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.y, Config.Shops[shopName]["ShowroomVehicles"][data.ClosestVehicle].coords.z, false, false)
         while not DoesEntityExist(veh) do
-            Citizen.Wait(250)
+            Wait(50)
         end
         SetModelAsNoLongerNeeded(model)        
         SetVehicleOnGroundProperly(veh)


### PR DESCRIPTION
Without this fix sometimes the vehicleshop will return the data of the previous car (because delete is slower than the swap)
Added Wait to make sure the car is deleted completely (This fixed the issue)
Added Wait to make sure the car is spawned completely (Just to make sure we Wait til low end PC-s load everything)
Moved chosenVehicle = data.toVehicle part a bit up for testing purposes.