### PR TITLE
Prevent players to doing test drive exploit.

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -149,6 +149,9 @@ local function startTestDriveTimer(testDriveTime)
             if GetGameTimer() < gameTimer + tonumber(1000 * testDriveTime) then
                 local secondsLeft = GetGameTimer() - gameTimer
                 drawTxt('Test Drive Time Remaining: '..math.ceil(testDriveTime - secondsLeft / 1000), 4, 0.5, 0.93, 0.50, 255, 255, 255, 180)
+		if GetVehiclePedIsUsing(PlayerPedId()) == 0 and DoesEntityExist(testDriveVeh) then
+                    SetPedIntoVehicle(PlayerPedId(), testDriveVeh, -1)
+                end
             end
             Wait(0)
         end


### PR DESCRIPTION


**Describe Pull request**
Video Link :- https://youtu.be/8QGooJkBM64

If your PR is to fix an issue mention that issue here

Issue Link :- https://github.com/qbcore-framework/qb-vehicleshop/issues/184#issue-1243788525

Describe the bug
Cars can be flooded for free in the vehicle shop using this exploit, also cars can be put on scrapyard for their benefit.

To Reproduce
Steps to reproduce the behavior:

Go to 'Vehicle Menu'
Click on 'Test Drive'
Go out of the vehicle and let someone enter to drive it.
Test drive car will not de-spawn after the timer runs out.


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
