### PR TITLE
feat: Add multiple shop support

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -505,21 +505,42 @@ RegisterNetEvent('qb-vehicleshop:client:openVehCats', function(data)
         }
     }
     for k, v in pairs(QBCore.Shared.Vehicles) do
-        if QBCore.Shared.Vehicles[k]["category"] == data.catName and QBCore.Shared.Vehicles[k]["shop"] == insideShop then
-            vehMenu[#vehMenu + 1] = {
-                header = v.name,
-                txt = Lang:t('menus.veh_price') .. v.price,
-                icon = "fa-solid fa-car-side",
-                params = {
-                    isServer = true,
-                    event = 'qb-vehicleshop:server:swapVehicle',
-                    args = {
-                        toVehicle = v.model,
-                        ClosestVehicle = ClosestVehicle,
-                        ClosestShop = insideShop
+        if QBCore.Shared.Vehicles[k]["category"] == data.catName then
+            if type(QBCore.Shared.Vehicles[k]["shop"]) == 'table' then
+                for _, shop in pairs(QBCore.Shared.Vehicles[k]["shop"]) do
+                    if shop == insideShop then
+                        vehMenu[#vehMenu + 1] = {
+                            header = v.name,
+                            txt = Lang:t('menus.veh_price') .. v.price,
+                            icon = "fa-solid fa-car-side",
+                            params = {
+                                isServer = true,
+                                event = 'qb-vehicleshop:server:swapVehicle',
+                                args = {
+                                    toVehicle = v.model,
+                                    ClosestVehicle = ClosestVehicle,
+                                    ClosestShop = insideShop
+                                }
+                            }
+                        }
+                    end
+                end
+            elseif QBCore.Shared.Vehicles[k]["shop"] == insideShop then
+                vehMenu[#vehMenu + 1] = {
+                    header = v.name,
+                    txt = Lang:t('menus.veh_price') .. v.price,
+                    icon = "fa-solid fa-car-side",
+                    params = {
+                        isServer = true,
+                        event = 'qb-vehicleshop:server:swapVehicle',
+                        args = {
+                            toVehicle = v.model,
+                            ClosestVehicle = ClosestVehicle,
+                            ClosestShop = insideShop
+                        }
                     }
                 }
-            }
+            end
         end
     end
     exports['qb-menu']:openMenu(vehMenu)


### PR DESCRIPTION
Adds the ability to list multiple shops in the shared like so:

['shop'] = {'pdm', 'luxury', 'paleto'} 