### PR TITLE
Added seat change check in testdrive

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -141,10 +141,11 @@ end
 local function startTestDriveTimer(testDriveTime, prevCoords)
     local gameTimer = GetGameTimer()
     CreateThread(function()
+	Wait(2000) -- Avoids the condition to run before entering vehicle
         while inTestDrive do
             if GetGameTimer() < gameTimer + tonumber(1000 * testDriveTime) then
                 local secondsLeft = GetGameTimer() - gameTimer
-                if secondsLeft >= tonumber(1000 * testDriveTime) - 20 then
+                if secondsLeft >= tonumber(1000 * testDriveTime) - 20 or GetPedInVehicleSeat(NetToVeh(testDriveVeh), -1) ~= PlayerPedId() then
                     TriggerServerEvent('qb-vehicleshop:server:deleteVehicle', testDriveVeh)
                     testDriveVeh = 0
                     inTestDrive = false


### PR DESCRIPTION
**Describe Pull request**
Fixed a bug in which the test drive car does not de-spawn after the time ends(if another player sits on the driver seat). To fix this, I added a seat check condition. So, whenever the player changes seat or gets out of vehicle, the test drive will end instantly. This will prevent the vehicle from not being de-spawned and exploiting the test-drive functionality.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
