### PR TITLE
Vehicle spawn logic

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -471,7 +471,6 @@ RegisterNetEvent('qb-vehicleshop:client:TestDrive', function()
             SetVehicleNumberPlateText(veh, vehPlate)
             exports['LegacyFuel']:SetFuel(veh, 100)
             TriggerEvent('vehiclekeys:client:SetOwner', vehPlate)
-            local playerPed = PlayerPedId()
             TaskWarpPedIntoVehicle(PlayerPedId(), veh, -1)
             SetVehicleEngineOn(veh, true, true, false)
             testDriveVeh = netId


### PR DESCRIPTION
With the old logic, 

- The vehicle spawn was a little bit inconsistent.  
- The vehicle spawns but not with the right plate.
- Does not give the keys since its not the write vehicle.

New method

- spawns the vehicle server side using the new natives
- makes sure it has the right plate


Some of the code has been taken from qb-garages as this one needed a little bit of an update.


